### PR TITLE
Add scripts to generate keys

### DIFF
--- a/CA/script/generate-ca-key.sh
+++ b/CA/script/generate-ca-key.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+CA_KEY_PATH="../storage/root-certificate/ca_key.pem"
+CA_CERT_PATH="../storage/root-certificate/ca_cert.pem"
+
+openssl genrsa -out $CA_KEY_PATH 2048
+openssl req -new -x509 -sha256 -key $CA_KEY_PATH -out $CA_CERT_PATH -days 365

--- a/website-daemon/generate-domain-key.sh
+++ b/website-daemon/generate-domain-key.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ $# != 1 ]
+then
+    echo "Usage: $0 [domain_name]"
+    exit 1
+fi
+
+source_dir="/home/nobellet/short-lived-cert/"
+
+privkey_dir="${source_dir}/website-daemon/storage/"
+privkey_filename="priv_key.pem"
+privkey_path="${privkey_dir}/${privkey_filename}"
+
+pubkey_dir="${source_dir}/CA/storage/domain-pubkey/$1/"
+pubkey_filename="pub_key.pem"
+pubkey_path="${pubkey_dir}/${pubkey_filename}"
+
+for dir in $pubkey_dir $privkey_dir; do
+    if [ ! -d ${dir} ]
+    then
+        echo "Making ${dir}"
+        mkdir -p ${dir}
+    fi
+done
+
+echo "Storing private key at ${privkey_path}"
+echo "Storing public key at ${pubkey_path}"
+openssl genrsa -out $privkey_path 2048
+openssl rsa -in $privkey_path -pubout -out $pubkey_path


### PR DESCRIPTION
This commit will add scripts to generate keys for CA and domain respectively.

### Note
`generate-ca-key.sh` can only be run from `CA/script/` to ensure generated keys are placed at the right directory. This is okay since the keys for CA can be reused for multiple domains.

`generate-domain-key.sh` can be run from anywhere because we'll run this frequently for different domains/hosts.